### PR TITLE
Add <C-b> and <C-f> motion mapping.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,7 +25,7 @@ While in the vim scrollback mode the following key bindings are available:
   - h j k l
   - w e b
   - 0 _ $
-  - ctrl-u ctrl-d
+  - ctrl-u ctrl-d ctrl-f ctrl-b
   - gg G
   - f<char> - jump to next occurrence of <char> on the current line
   - F<char> - jump to prev occurrence of <char> on the current line

--- a/vim-scrollback
+++ b/vim-scrollback
@@ -491,12 +491,22 @@ sub key_press_normal {
       $self->move_cursor($event, $self->{orig_lnum}, $self->{orig_cnum});
    } elsif ($string =~ /^\cD$/) {
       my ($lnum, $cnum) = $self->screen_cur();
-      my $row = $lnum + 20;
+      my $row = $lnum + $self->nrow / 2;
       $row = $row < $self->{orig_lnum} ? $row : $self->{orig_lnum};
       $self->move_cursor($event, $row, $cnum);
    } elsif ($string =~ /^\cU$/) {
       my ($lnum, $cnum) = $self->screen_cur();
-      my $row = $lnum - 20;
+      my $row = $lnum - $self->nrow / 2;
+      $row = $row > $self->top_row ? $row : $self->top_row;
+      $self->move_cursor($event, $row, $cnum);
+   } elsif ($string =~ /^\cF$/) {
+      my ($lnum, $cnum) = $self->screen_cur();
+      my $row = $lnum + $self->nrow - 1;
+      $row = $row < $self->{orig_lnum} ? $row : $self->{orig_lnum};
+      $self->move_cursor($event, $row, $cnum);
+   } elsif ($string =~ /^\cB$/) {
+      my ($lnum, $cnum) = $self->screen_cur();
+      my $row = $lnum - $self->nrow + 1;
       $row = $row > $self->top_row ? $row : $self->top_row;
       $self->move_cursor($event, $row, $cnum);
    } elsif ($string eq "w" or $string eq "e") {


### PR DESCRIPTION
Add the <C-b> mapping to scroll back a full terminal height.
Add the <C-f> mapping to scroll forth a full terminal height.
Also adjust the <C-u> and <C-d> mapping to scroll half a terminal height
instead of a hard coded value of 20.
